### PR TITLE
Travis: exclude new branch from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,7 @@ script:
 
 after_success:
   - travis_after_tests_success
+
+branches:
+  except:
+    - /^merge-branch-.*$/


### PR DESCRIPTION
This pull-request is here only to show that there is no bug and we are adding only `travis-exclude`